### PR TITLE
Initialize data load and totals toggle

### DIFF
--- a/ConferenceScorePad.csproj
+++ b/ConferenceScorePad.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0-preview.7.23375.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0-preview.7.23375.6" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.7" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Pages/Entry.razor
+++ b/Pages/Entry.razor
@@ -60,9 +60,10 @@
 </table>
 
 @code {
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         formModel = new();
+        await EventLookup.InitializeAsync();
     }
 
     private FormModel formModel = new();
@@ -85,25 +86,10 @@
         formModel = new(); // reset
     }
 
-    private void Delete(Result r)
+    private async Task Delete(Result r)
     {
-        // remove and re-add without this swimmer, easiest way
-        var toRemove = ResultService.Results.FirstOrDefault(x => x.EventNumber == r.EventNumber && x.SwimmerKey == r.SwimmerKey);
-        if(toRemove != null)
-        {
-            var list = ResultService.Results.ToList();
-            list.Remove(toRemove);
-            ResultService.Results.Clear();
-            foreach(var item in list) ResultService.Results.Add(item);
-
-            // workaround for recalculating places
-            foreach(var evNum in list.Select(l=>l.EventNumber).Distinct())
-            {
-                foreach(var rr in list.Where(l=>l.EventNumber==evNum))
-                    ResultService.AddOrUpdate(rr);
-            }
-            Storage.SaveAsync(ResultService.Results);
-        }
+        ResultService.Remove(r.EventNumber, r.SwimmerKey);
+        await Storage.SaveAsync(ResultService.Results);
     }
 
     private static double ParseTime(string input)

--- a/Pages/Totals.razor
+++ b/Pages/Totals.razor
@@ -4,41 +4,60 @@
 @inject RosterService Roster
 @inject ScoringService Scoring
 
-<h3>Team Totals</h3>
-<table class="table table-bordered">
-    <thead><tr><th>Team</th><th>Points</th></tr></thead>
-    <tbody>
-        @foreach(var row in TeamTotals.OrderByDescending(t=>t.Value))
-        {
-            <tr><td>@row.Key</td><td>@row.Value</td></tr>
-        }
-    </tbody>
-</table>
-
-<h3>Age‑Group Totals</h3>
-@foreach(var grp in AgeGroups)
+@if (TotalsVisibility?.ShowTotals ?? true)
 {
-    <h5>@grp</h5>
-    <table class="table table-sm table-striped">
+    <h3>Team Totals</h3>
+    <table class="table table-bordered">
         <thead><tr><th>Team</th><th>Points</th></tr></thead>
         <tbody>
-            @foreach(var row in AgeGroupTotals[grp].OrderByDescending(t=>t.Value))
+            @foreach(var row in TeamTotals.OrderByDescending(t=>t.Value))
             {
                 <tr><td>@row.Key</td><td>@row.Value</td></tr>
             }
         </tbody>
     </table>
+
+    <h3>Age‑Group Totals</h3>
+    @foreach(var grp in AgeGroups)
+    {
+        <h5>@grp</h5>
+        <table class="table table-sm table-striped">
+            <thead><tr><th>Team</th><th>Points</th></tr></thead>
+            <tbody>
+                @foreach(var row in AgeGroupTotals[grp].OrderByDescending(t=>t.Value))
+                {
+                    <tr><td>@row.Key</td><td>@row.Value</td></tr>
+                }
+            </tbody>
+        </table>
+    }
+}
+else
+{
+    <p class="text-muted">Totals hidden.</p>
 }
 
+@implements IDisposable
 @code {
+    [CascadingParameter] public TotalsVisibilityService? TotalsVisibility { get; set; }
     private string[] AgeGroups = { "6 & U","7-8","9-10","11-12","13-14","15-18"};
     private Dictionary<string,int> TeamTotals = new();
     private Dictionary<string,Dictionary<string,int>> AgeGroupTotals = new();
 
-    protected override void OnParametersSet()
+    private void VisibilityChanged() => InvokeAsync(StateHasChanged);
+
+    protected override void OnInitialized()
     {
         Recalc();
-        ResultService.Results.CollectionChanged += (_,__) => { Recalc(); StateHasChanged(); };
+        ResultService.Results.CollectionChanged += (_,__) => { Recalc(); InvokeAsync(StateHasChanged); };
+        if (TotalsVisibility != null)
+            TotalsVisibility.OnChange += VisibilityChanged;
+    }
+
+    public void Dispose()
+    {
+        if (TotalsVisibility != null)
+            TotalsVisibility.OnChange -= VisibilityChanged;
     }
 
     private void Recalc()

--- a/Program.cs
+++ b/Program.cs
@@ -3,18 +3,31 @@ using ConferenceScorePad;
 using ConferenceScorePad.Services;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using System.Net.Http;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
+
+// Http client for loading static data
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
 // Register services
 builder.Services.AddSingleton<EventLookupService>();
 builder.Services.AddSingleton<ScoringService>();
 builder.Services.AddSingleton<ResultService>();
 builder.Services.AddSingleton<RosterService>();
+builder.Services.AddSingleton<TotalsVisibilityService>();
 builder.Services.AddScoped<StorageService>();
 
-await builder.Build().RunAsync();
+var host = builder.Build();
 
-builder.Services.AddSingleton<TotalsVisibilityService>();
+// preload events and any stored results
+var events = host.Services.GetRequiredService<EventLookupService>();
+await events.InitializeAsync();
+var storage = host.Services.GetRequiredService<StorageService>();
+var resultService = host.Services.GetRequiredService<ResultService>();
+foreach (var r in await storage.LoadAsync())
+    resultService.AddOrUpdate(r);
+
+await host.RunAsync();

--- a/Services/EventLookupService.cs
+++ b/Services/EventLookupService.cs
@@ -1,28 +1,32 @@
 
 using ConferenceScorePad.Models;
-using System.Globalization;
-using System.Reflection;
+using System.Net.Http;
 
 namespace ConferenceScorePad.Services
 {
     public class EventLookupService
     {
+        private readonly HttpClient _http;
         private readonly Dictionary<int, MeetEvent> _events = new();
-        public EventLookupService()
+
+        public EventLookupService(HttpClient http)
         {
-            // load csv from embedded resource or wwwroot
-            var path = Path.Combine(AppContext.BaseDirectory, "wwwroot", "data", "events.csv");
-            if (File.Exists(path))
+            _http = http;
+        }
+
+        public async Task InitializeAsync()
+        {
+            if (_events.Count > 0) return;
+
+            var csv = await _http.GetStringAsync("data/events.csv");
+            using var reader = new StringReader(csv);
+            string? line;
+            while ((line = reader.ReadLine()) != null)
             {
-                using var reader = new StreamReader(path);
-                string? line;
-                while ((line = reader.ReadLine()) != null)
-                {
-                    var parts = line.Split(',');
-                    if (parts.Length < 6 || !int.TryParse(parts[0], out var num)) continue;
-                    var ev = new MeetEvent(num, parts[1], parts[2], parts[3], parts[4], parts[5].Trim().ToLower() == "true");
-                    _events[num] = ev;
-                }
+                var parts = line.Split(',');
+                if (parts.Length < 6 || !int.TryParse(parts[0], out var num)) continue;
+                var ev = new MeetEvent(num, parts[1], parts[2], parts[3], parts[4], parts[5].Trim().ToLower() == "true");
+                _events[num] = ev;
             }
         }
 

--- a/Services/ResultService.cs
+++ b/Services/ResultService.cs
@@ -56,5 +56,43 @@ namespace ConferenceScorePad.Services
             foreach(var evList in _byEvent.Values.SelectMany(x=>x))
                 Results.Add(evList);
         }
+
+        public void Remove(int eventNumber, string swimmerKey)
+        {
+            if (!_byEvent.TryGetValue(eventNumber, out var list))
+                return;
+
+            list.RemoveAll(r => r.SwimmerKey == swimmerKey);
+            if (list.Count == 0)
+            {
+                _byEvent.Remove(eventNumber);
+            }
+            else
+            {
+                list.Sort((a, b) => a.TimeSeconds.CompareTo(b.TimeSeconds));
+                double? prevTime = null;
+                int prevPlace = 0;
+                for (int i = 0; i < list.Count; i++)
+                {
+                    var current = list[i];
+                    int place;
+                    if (prevTime.HasValue && Math.Abs(current.TimeSeconds - prevTime.Value) < 0.0001)
+                    {
+                        place = prevPlace;
+                    }
+                    else
+                    {
+                        place = i + 1;
+                        prevPlace = place;
+                        prevTime = current.TimeSeconds;
+                    }
+                    list[i] = current with { Place = place };
+                }
+            }
+
+            Results.Clear();
+            foreach (var evList in _byEvent.Values.SelectMany(x => x))
+                Results.Add(evList);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- load meet events and persisted results on startup
- register HTTP client and TotalsVisibilityService correctly
- rework EventLookupService to fetch `events.csv`
- simplify result deletion logic
- let totals page respect visibility toggle
- update Blazor packages to ASP.NET Core 8 stable
- fix totals component IDisposable syntax
- bump package references to ASP.NET Core 8.0.7

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68717f25a9cc832f9a704d9284d5e967