### PR TITLE
Enable Swagger and open CORS

### DIFF
--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -3,7 +3,32 @@ using ConferenceScorePad.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Register Swagger/OpenAPI services
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+// Allow CORS from any origin so the Blazor client can access the API
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.AllowAnyOrigin()
+              .AllowAnyHeader()
+              .AllowAnyMethod();
+    });
+});
+
 var app = builder.Build();
+
+// Enable CORS
+app.UseCors();
+
+// Enable Swagger in development
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
 
 string dataPath = Path.Combine(app.Environment.ContentRootPath, "Data", "results.json");
 


### PR DESCRIPTION
## Summary
- enable Swagger/OpenAPI for the backend
- allow all CORS requests so the Blazor client can access the backend

## Testing
- `dotnet build ConferenceScorePad.sln`

------
https://chatgpt.com/codex/tasks/task_e_6873076d3bfc832f9bc6609971d6e1e8