### PR TITLE
Fix events.csv fetch failure

### DIFF
--- a/ConferenceScorePad.csproj
+++ b/ConferenceScorePad.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.7" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Program.cs
+++ b/Program.cs
@@ -7,9 +7,13 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-// HttpClient that points at the site root
+// HttpClient for static files (CSV/JSON) served by the Blazor app
 builder.Services.AddScoped(sp =>
-    new HttpClient { BaseAddress = new("https://localhost:7263/") });
+    new HttpClient { BaseAddress = new(builder.HostEnvironment.BaseAddress) });
+
+// Separate client for backend API calls
+builder.Services.AddHttpClient("backend", client =>
+    client.BaseAddress = new("https://localhost:7263/"));
 
 // DI registrations
 builder.Services.AddScoped<EventLookupService>();

--- a/Services/StorageService.cs
+++ b/Services/StorageService.cs
@@ -1,5 +1,6 @@
 
 using ConferenceScorePad.Models;
+using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
 
@@ -9,9 +10,9 @@ namespace ConferenceScorePad.Services
     {
         private readonly HttpClient _http;
 
-        public StorageService(HttpClient http)
+        public StorageService(IHttpClientFactory httpFactory)
         {
-            _http = http;
+            _http = httpFactory.CreateClient("backend");
         }
 
         public async Task SaveAsync(IEnumerable<Result> results)


### PR DESCRIPTION
## Summary
- fix `events.csv` load error by configuring default HttpClient to use the app's base address
- register a separate HttpClient for backend API calls
- update `StorageService` to use a named backend client
- add `Microsoft.Extensions.Http` package reference

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68730becc684832f91e930ee0a0660c7