### PR TITLE
Fix deployment pipeline and host client from API

### DIFF
--- a/.github/workflows/main_liveatticusswims.yml
+++ b/.github/workflows/main_liveatticusswims.yml
@@ -26,14 +26,23 @@ jobs:
       - name: Build with dotnet
         run: dotnet build --configuration Release
 
-      - name: dotnet publish
-        run: dotnet publish -c Release -o "${{env.DOTNET_ROOT}}/myapp"
+      - name: Publish client
+        run: dotnet publish ConferenceScorePad.csproj -c Release -o clientapp
+
+      - name: Publish backend
+        run: dotnet publish Backend/Backend.csproj -c Release -o app
+
+      - name: Copy client to backend wwwroot
+        run: |
+          mkdir -p app/wwwroot
+          cp -r clientapp/wwwroot/* app/wwwroot/
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4
         with:
           name: .net-app
-          path: ${{env.DOTNET_ROOT}}/myapp
+          path: app
+
 
   deploy:
     runs-on: windows-latest

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -3,6 +3,10 @@ using Microsoft.AspNetCore.Mvc;
 using System.Text.Json;
 
 var builder = WebApplication.CreateBuilder(args);
+if (builder.Environment.IsDevelopment())
+{
+    builder.WebHost.UseWebRoot(Path.Combine("..", "wwwroot"));
+}
 
 // Register Swagger/OpenAPI services
 builder.Services.AddEndpointsApiExplorer();
@@ -30,6 +34,10 @@ var app = builder.Build();
 
 // Enable CORS
 app.UseCors();
+
+// Serve the Blazor WebAssembly files
+app.UseDefaultFiles();
+app.UseStaticFiles();
 
 // Enable Swagger in development
 if (app.Environment.IsDevelopment())
@@ -59,5 +67,8 @@ app.MapPost("/api/results", async ([FromBody] List<Result> results) =>
     await File.WriteAllTextAsync(dataPath, json);
     return Results.Ok();
 });
+
+// Fallback for client-side routes
+app.MapFallbackToFile("index.html");
 
 app.Run();

--- a/Program.cs
+++ b/Program.cs
@@ -12,8 +12,14 @@ builder.Services.AddScoped(sp =>
     new HttpClient { BaseAddress = new(builder.HostEnvironment.BaseAddress) });
 
 // Separate client for backend API calls
+var backendUrl = builder.Configuration["BackendUrl"];
 builder.Services.AddHttpClient("backend", client =>
-    client.BaseAddress = new("https://localhost:7263/"));
+{
+    var url = string.IsNullOrWhiteSpace(backendUrl)
+        ? builder.HostEnvironment.BaseAddress
+        : backendUrl;
+    client.BaseAddress = new(url);
+});
 
 // DI registrations
 builder.Services.AddScoped<EventLookupService>();

--- a/README.md
+++ b/README.md
@@ -6,16 +6,14 @@ visitors share the same data.
 
 ## Running
 
-1. Start the backend API:
+1. Start the backend API (which now also serves the Blazor app):
    ```bash
    dotnet run --project Backend
    ```
    The service listens at `https://localhost:7263` and manages `Data/results.json`.
 
-2. In another terminal run the WebAssembly app:
-   ```bash
-   dotnet run --project ConferenceScorePad.csproj
-   ```
+   To override the API URL used by the Blazor client, set the `BackendUrl` environment
+   variable when running the app.
 
-Both projects are part of `ConferenceScorePad.sln` and can be built together
-with `dotnet build`.
+Both projects are part of `ConferenceScorePad.sln` and can be built together with
+`dotnet build`. The backend hosts the compiled WebAssembly files from `wwwroot`.


### PR DESCRIPTION
## Summary
- host static files from Backend and fall back to index.html
- allow overriding Backend URL with `BackendUrl` setting
- update Azure deployment workflow to package client with API
- document the new unified hosting approach

## Testing
- `dotnet build --configuration Release`
- `dotnet publish ConferenceScorePad.csproj -c Release -o client_tmp`
- `dotnet publish Backend/Backend.csproj -c Release -o app_tmp`
- `mkdir -p app_tmp/wwwroot && cp -r client_tmp/wwwroot/* app_tmp/wwwroot/`
- `dotnet app_tmp/Backend.dll --urls http://localhost:5006` *(served index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68731fb08a6c832fab82c94c9b7f7726