### PR TITLE
Fix 404 for icudt data files

### DIFF
--- a/wwwroot/web.config
+++ b/wwwroot/web.config
@@ -17,6 +17,8 @@
     <staticContent>
       <!-- Tell IIS how to serve .webp -->
       <mimeMap fileExtension=".webp" mimeType="image/webp" />
+      <!-- Serve ICU data files used by Blazor WebAssembly -->
+      <mimeMap fileExtension=".dat" mimeType="application/octet-stream" />
     </staticContent>
   </system.webServer>
 </configuration>


### PR DESCRIPTION
## Summary
- allow IIS to serve `.dat` files

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_687323d4084c832fa3ed6baca449e365